### PR TITLE
Don't have UI in upload service anymore

### DIFF
--- a/services/upload-service/Dockerfile
+++ b/services/upload-service/Dockerfile
@@ -8,8 +8,6 @@ RUN pip install -r requirements.txt
 
 COPY . /opt/app
 
-EXPOSE 5000
-
 # 1MiB
 ENV MAX_IMG_SIZE_IN_BYTES=1000000
 ENV MAX_IMG_WIDTH=640
@@ -22,6 +20,8 @@ ENV PORT=8080
 ENV WORKERS=1
 ENV THREADS=8
 ENV TIMEOUT=0
+
+EXPOSE $PORT
 
 CMD exec gunicorn --bind :$PORT --workers $WORKERS --threads $THREADS --timeout $TIMEOUT app:app
 

--- a/services/upload-service/README.md
+++ b/services/upload-service/README.md
@@ -37,12 +37,25 @@ spec:
 EOF
 
 # allow network access
-kubectl port-forward pod/minio --address 0.0.0.0 9000 9090 -n minio-dev
+kubectl port-forward pod/minio --address 0.0.0.0 9445 9090 -n minio-dev --address=0.0.0.0
+```
 
+Or, if you already have a Minio instance running on Kubernetes, you can use that.
+
+```shell
+kubectl port-forward -n minio-operator svc/minio 9445:443 --address=0.0.0.0
+```
+
+## Create a bucket
+```shell
 # Create a bucket named "ai-demo"
 python - <<EOF
 import boto3
-s3 = boto3.resource('s3', endpoint_url='http://localhost:9000', aws_access_key_id='minio', aws_secret_access_key='minio1234')
+s3 = boto3.resource('s3', endpoint_url='http://localhost:9445', aws_access_key_id='minio', aws_secret_access_key='minio1234', verify=False)
+
+# OR 
+# s3 = boto3.resource('s3', endpoint_url='https://localhost:9445', aws_access_key_id='minio', aws_secret_access_key='minio1234', verify=False)
+
 s3.create_bucket(Bucket="ai-demo")
 EOF
 ```
@@ -62,17 +75,21 @@ pip install -r requirements.txt
 
 Run:
 ```shell
-S3_ENDPOINT_URL="http://localhost:9000" \
+PORT=8081 \
+S3_ENDPOINT_URL="https://localhost:9445" \
 S3_ACCESS_KEY_ID="minio" \
 S3_ACCESS_KEY_SECRET="minio1234" \
 S3_ACCESS_SSL_VERIFY="false" \
 S3_BUCKET_NAME="ai-demo" \
-flask --app main --debug run
+python app.py
 ```
 
 Test:
 ```shell
-curl localhost:5000
+curl 'http://localhost:8081/' \
+  -H 'Accept: application/json, text/javascript, */*; q=0.01' \
+  -H 'Content-Type: application/json; charset=UTF-8' \
+  --data-raw '{"image_b64":"iVBORw0KGgoAAAANSUhEUgAAAAoAAAAOCAYAAAAWo42rAAAAAXNSR0IArs4c6QAAAfxJREFUKFMty8FLU3EAwPHv7/d7czmF2JxhguGhP6BjdCgRKsJiFA6pLBN3CKIMk/RQqKiHVRgYGQgRER46BBURJSYFGYIUWo6VOhDKydya5qbrvbe3X6DdPx/R2lyvTzWF2F1ZhTIMlJIoKdnIbRKdmCD28hWv42lEW0vDFtxVUfkfqi2Yyazz9d0Y8fH32/Ba6Iyubw7hL69Aqm1kGIrVdIrI21ESU58Zmf6G6LjYpOsvtOD1+ZFK4i4y0FqQTCzz480o8dkIfeMTiBuXQ/rkuWZ8Ph+2lqxkHarL3CSXl5h+9pzFSISeT9OI7vZLOnC6Ea/Xy9RClqfRv/QcLiO/nuBh+D6/PkZ44SQRvZ1XdbCxkVRW8uTDb3Z6ithbLtm/x6K39Q6J2UUmi1cQ4a5OHQgGWTcVw2NJXIZBYJ+HMrnKg9Z7fPk+w0xJDjHQf1MfOR6gpLSE1JqNnddU+V3MR+cZaR/ip7PGaDqGGB68pQ/U1LKjuBSPx40UsJHNsRCd43Ggn0liJKvLEUN3w/pgzSGUoRBCIaVA2ybZ1TTJeIKZuRgd3Y8QJ+rqdF9XB0pqLNNEODYeo0Ahb4ME27JYiicQ19uu6PNnGzDNHLpQQDoWRcImb1lYZg60g8ulEIMDt/Wxo7VkM39w8g4qv4nSFrZlYpmbaMfZCv8A05jsaQzcdV8AAAAASUVORK5CYII="}'
 ```
 
 
@@ -92,8 +109,9 @@ docker build . -t ${DOCKER_REPO_OVERRIDE}/upload-service
 Run the image:
 ```shell
 docker run --rm \
--p 8080:8080 \
--e S3_ENDPOINT_URL="http://192.168.2.160:9000" \
+-p 8081:8081 \
+-e PORT="8081" \
+-e S3_ENDPOINT_URL="https://192.168.2.160:9445" \
 -e S3_ACCESS_KEY_ID="minio" \
 -e S3_ACCESS_KEY_SECRET="minio1234" \
 -e S3_ACCESS_SSL_VERIFY="false" \
@@ -103,5 +121,8 @@ ${DOCKER_REPO_OVERRIDE}/upload-service
 
 Test the image:
 ```shell
-curl localhost:8080
+curl 'http://localhost:8081/' \
+  -H 'Accept: application/json, text/javascript, */*; q=0.01' \
+  -H 'Content-Type: application/json; charset=UTF-8' \
+  --data-raw '{"image_b64":"iVBORw0KGgoAAAANSUhEUgAAAAoAAAAOCAYAAAAWo42rAAAAAXNSR0IArs4c6QAAAfxJREFUKFMty8FLU3EAwPHv7/d7czmF2JxhguGhP6BjdCgRKsJiFA6pLBN3CKIMk/RQqKiHVRgYGQgRER46BBURJSYFGYIUWo6VOhDKydya5qbrvbe3X6DdPx/R2lyvTzWF2F1ZhTIMlJIoKdnIbRKdmCD28hWv42lEW0vDFtxVUfkfqi2Yyazz9d0Y8fH32/Ba6Iyubw7hL69Aqm1kGIrVdIrI21ESU58Zmf6G6LjYpOsvtOD1+ZFK4i4y0FqQTCzz480o8dkIfeMTiBuXQ/rkuWZ8Ph+2lqxkHarL3CSXl5h+9pzFSISeT9OI7vZLOnC6Ea/Xy9RClqfRv/QcLiO/nuBh+D6/PkZ44SQRvZ1XdbCxkVRW8uTDb3Z6ithbLtm/x6K39Q6J2UUmi1cQ4a5OHQgGWTcVw2NJXIZBYJ+HMrnKg9Z7fPk+w0xJDjHQf1MfOR6gpLSE1JqNnddU+V3MR+cZaR/ip7PGaDqGGB68pQ/U1LKjuBSPx40UsJHNsRCd43Ggn0liJKvLEUN3w/pgzSGUoRBCIaVA2ybZ1TTJeIKZuRgd3Y8QJ+rqdF9XB0pqLNNEODYeo0Ahb4ME27JYiicQ19uu6PNnGzDNHLpQQDoWRcImb1lYZg60g8ulEIMDt/Wxo7VkM39w8g4qv4nSFrZlYpmbaMfZCv8A05jsaQzcdV8AAAAASUVORK5CYII="}'
 ```

--- a/services/upload-service/app.py
+++ b/services/upload-service/app.py
@@ -8,7 +8,8 @@ import uuid
 import boto3
 import botocore
 from PIL import Image
-from flask import Flask, render_template, request
+from flask import Flask, request
+from flask_cors import CORS, cross_origin
 
 MAX_IMG_SIZE_IN_BYTES = int(os.environ.get("MAX_IMG_SIZE_IN_BYTES", 1000 * 1000))
 MAX_IMG_WIDTH = int(os.environ.get("MAX_IMG_WIDTH", 640))
@@ -30,6 +31,8 @@ if not S3_BUCKET_NAME:
     raise Exception("Missing S3_BUCKET_NAME")
 
 app = Flask(__name__)
+cors = CORS(app)
+app.config['CORS_HEADERS'] = 'Content-Type'
 
 boto_config = botocore.client.Config(connect_timeout=5, retries={'max_attempts': 1})
 
@@ -61,13 +64,9 @@ signal.signal(signal.SIGINT, handler)
 signal.signal(signal.SIGTERM, handler)
 
 
-@app.get('/')
-def send_client_html():
-    return render_template('index.html', max_img_width=MAX_IMG_WIDTH, max_img_height=MAX_IMG_HEIGHT)
-
-
-@app.post("/upload")
-def hello_world():
+@app.post("/")
+@cross_origin()
+def upload_request():
     print("Received request")
 
     # set req size limit in Flask

--- a/services/upload-service/requirements.txt
+++ b/services/upload-service/requirements.txt
@@ -3,3 +3,4 @@ pillow==10.0.0
 requests==2.31.0
 boto3==1.28.48
 gunicorn==21.2.0
+flask-cors==4.0.0


### PR DESCRIPTION
- Remove HTML+JS client from the upload service
- Update instructions to test-run the upload service with curl
- Update instructions to start the upload service on port 8081 when testing locally
- Enable CORS on upload service