### PR TITLE
Automate minio webhook creation

### DIFF
--- a/infra/openshift-manifests/install.sh
+++ b/infra/openshift-manifests/install.sh
@@ -13,8 +13,9 @@ done
 
 patch_knative_serving
 
-create_minio_endpoint_route && create_bucket
+create_minio_endpoint_route && create_minio_client_config && create_bucket && add_minio_webhook
 delete_minio_endpoint_route
+delete_minio_client_config
 
 patch_ui_service_configmap
 

--- a/infra/openshift-manifests/lib.sh
+++ b/infra/openshift-manifests/lib.sh
@@ -48,7 +48,7 @@ function delete_minio_endpoint_route(){
 
 function add_minio_webhook(){
     # wait until minio-webhook-source Knative Service are ready
-    oc wait --for=condition=Ready ksvc -n ai-demo upload-service
+    oc wait --for=condition=Ready ksvc -n ai-demo minio-webhook-source
 
     # get the internal address of the minio webhook service
     endpoint=$(oc get ksvc -n ai-demo minio-webhook-source -ojsonpath="{.status.address.url}")


### PR DESCRIPTION
Automate minio webhook creation:
- Use `mc` command in Docker
- Create temp dir to hold `mc` client config, mount it to the `mc` image, run commands, delete the temp dir