### PR TITLE
Disable python ssl warnings

### DIFF
--- a/services/analytics-service/Dockerfile
+++ b/services/analytics-service/Dockerfile
@@ -10,6 +10,8 @@ COPY . /opt/app
 
 # Allow statements and log messages to immediately appear in the logs
 ENV PYTHONUNBUFFERED True
+# Disable warnings in the logs about unverified HTTPS requests
+ENV PYTHONWARNINGS="ignore:Unverified HTTPS request"
 
 ENV PORT=8080
 ENV WORKERS=1

--- a/services/minio-webhook-source/Dockerfile
+++ b/services/minio-webhook-source/Dockerfile
@@ -10,6 +10,8 @@ COPY . /opt/app
 
 # Allow statements and log messages to immediately appear in the logs
 ENV PYTHONUNBUFFERED True
+# Disable warnings in the logs about unverified HTTPS requests
+ENV PYTHONWARNINGS="ignore:Unverified HTTPS request"
 
 ENV PORT=8080
 ENV WORKERS=1

--- a/services/prediction-service/Dockerfile
+++ b/services/prediction-service/Dockerfile
@@ -10,6 +10,8 @@ COPY . /opt/app
 
 # Allow statements and log messages to immediately appear in the logs
 ENV PYTHONUNBUFFERED True
+# Disable warnings in the logs about unverified HTTPS requests
+ENV PYTHONWARNINGS="ignore:Unverified HTTPS request"
 
 ENV S3_BUCKET_NAME='ai-demo'
 ENV S3_ACCESS_SSL_VERIFY='true'

--- a/services/reply-service/Dockerfile
+++ b/services/reply-service/Dockerfile
@@ -10,6 +10,8 @@ COPY . /opt/app
 
 # Allow statements and log messages to immediately appear in the logs
 ENV PYTHONUNBUFFERED True
+# Disable warnings in the logs about unverified HTTPS requests
+ENV PYTHONWARNINGS="ignore:Unverified HTTPS request"
 
 ENV MAX_ITEMS_IN_CACHES=1000000
 ENV CACHE_ITEM_TTL_IN_SECONDS=300

--- a/services/ui-service/Dockerfile
+++ b/services/ui-service/Dockerfile
@@ -10,6 +10,8 @@ COPY . /opt/app
 
 # Allow statements and log messages to immediately appear in the logs
 ENV PYTHONUNBUFFERED True
+# Disable warnings in the logs about unverified HTTPS requests
+ENV PYTHONWARNINGS="ignore:Unverified HTTPS request"
 
 ENV PORT=8080
 ENV WORKERS=1

--- a/services/upload-service/Dockerfile
+++ b/services/upload-service/Dockerfile
@@ -10,6 +10,8 @@ COPY . /opt/app
 
 # Allow statements and log messages to immediately appear in the logs
 ENV PYTHONUNBUFFERED True
+# Disable warnings in the logs about unverified HTTPS requests
+ENV PYTHONWARNINGS="ignore:Unverified HTTPS request"
 
 # 1MiB
 ENV MAX_IMG_SIZE_IN_BYTES=1000000


### PR DESCRIPTION
Disable python ssl warnings

It is very annoying in the logs